### PR TITLE
Adding move and delete cover art post download functionality

### DIFF
--- a/client/src/renderer/src/components/Settings.jsx
+++ b/client/src/renderer/src/components/Settings.jsx
@@ -28,7 +28,7 @@ function Settings(){
     const tabItems = [
     {
         key: '1',
-        label: 'Add to Filter',
+        label: 'Video Filter',
         children: 
         <div className="text-center mt-[20px]">
             <FilterForm setRefresh={setRefresh}/>
@@ -44,49 +44,6 @@ function Settings(){
     },
     {
         key: '3',
-        label: 
-        <>
-            <div className="flex">
-                {/* <div className="text-red-500 mr-[5px] visible">
-                    NEW
-                </div> */}
-                <div className="">
-                    Title filter
-                </div>                
-            </div>
-
-        </>,
-        children:
-        <div className="text-center mt-[20px]">
-            <FileNameFilter refreshRecords={refreshRecords} setRefresh={setRefresh}/>
-        </div>
-    },
-    {
-        key: '4',
-        label: 'Reorder Tracks',
-        children: 
-        <div className="text-center mt-[50px]">
-            <ReorderTracks />
-        </div>
-    },
-    {
-        key: '5',
-        label: 'Crop',
-        children: 
-        <div className="text-center mt-[0px]">
-            <Crop />
-        </div>
-    },
-    {
-        key: '6',
-        label: 'Edit Meta Data',
-        children: 
-        <div className="text-center mt-[30px]">
-            <EditMetaData />
-        </div>
-    },
-    {
-        key: '7',
         label: 
         <> 
             <div className="flex">
@@ -106,6 +63,50 @@ function Settings(){
         </>
 
     },
+    {
+        key: '4',
+        label: 
+        <>
+            <div className="flex">
+                {/* <div className="text-red-500 mr-[5px] visible">
+                    NEW
+                </div> */}
+                <div className="">
+                    Title filter
+                </div>                
+            </div>
+
+        </>,
+        children:
+        <div className="text-center mt-[20px]">
+            <FileNameFilter refreshRecords={refreshRecords} setRefresh={setRefresh}/>
+        </div>
+    },
+    {
+        key: '5',
+        label: 'Reorder Tracks',
+        children: 
+        <div className="text-center mt-[50px]">
+            <ReorderTracks />
+        </div>
+    },
+    {
+        key: '6',
+        label: 'Crop',
+        children: 
+        <div className="text-center mt-[0px]">
+            <Crop />
+        </div>
+    },
+    {
+        key: '7',
+        label: 'Edit Meta Data',
+        children: 
+        <div className="text-center mt-[30px]">
+            <EditMetaData />
+        </div>
+    },
+
     {
         key: '8',
         label: 'Merge folders',

--- a/client/src/renderer/src/components/downloadSettings/DownloadSettingsForm.jsx
+++ b/client/src/renderer/src/components/downloadSettings/DownloadSettingsForm.jsx
@@ -157,12 +157,19 @@ function DownloadSettingsForm({downloadType, setDownloadSettings, skipDownload, 
                     ...oldData
                 }
             })
+            setChosenPlaylistSetting('')
 
             setDownloadSettings(prev => {return {...prev}})
             setGallerySettings(prev => {
                 if (prev.showPagination){
                     return prev
+                }   
+                if (prev.allImages.length === 0){
+                    return {
+                        ...prev, showPagination : false
+                    }
                 }
+                console.log(2)
                 return {
                     ...prev, 
                     currentImagesShown: prev.imagesToNotShow && downloadType !== 'track' ? prev.imagesToNotShow.slice(0, imagesPerPage) : albumCoverFileNames.slice(0, imagesPerPage), 
@@ -188,14 +195,26 @@ function DownloadSettingsForm({downloadType, setDownloadSettings, skipDownload, 
             return newSettings;
         })
         
-        // if (downloadType === 'channel' && gallerySettings.prevUsedChannelArr){
+
         if (downloadType === 'channel'){
                 setGallerySettings(prev => {
-                console.log(`prev: ${JSON.stringify(prev)}`)
-                return {...prev}
+                if (prev.allImages.length === 0){
+                   
+                    return {
+                        ...prev, showPagination : false
+                    }
+                }
+                return prev
             })  
         }else{
-            setGallerySettings(prev => {return {...prev, showPagination : true}})
+            setGallerySettings(prev => {
+                if (prev.allImages.length === 0){
+                   
+                    return {
+                        ...prev, showPagination : false
+                    }
+                }
+                return {...prev, showPagination : true}})
         }
     }
 
@@ -249,6 +268,7 @@ function DownloadSettingsForm({downloadType, setDownloadSettings, skipDownload, 
                 delete copy['addToExistingPlaylistSettings']
                 return copy
             })
+            setChosenPlaylistSetting('')
 
             setUsePrevData(false)
             setGallerySettings(prev => {
@@ -327,7 +347,7 @@ function DownloadSettingsForm({downloadType, setDownloadSettings, skipDownload, 
             if (getPlaylistData.data.coverArtFile.includes('ERROR COULD NOT FIND FILE')){
                 notification.error({ message: 'File may have been deleted or renamed, please recover the file' });
                 notification.error({ message: getPlaylistData.data.coverArtFile})
-                setGallerySettings(prev => {return {...prev, currentImagesShown: []}})
+                setGallerySettings(prev => {return {...prev, currentImagesShown: [], showPagination : false}})
                 setPrevPlaylistArt(prev => {return {...prev, prevCoverArtUsed: null}})
             }else{
                 setPrevPlaylistArt(prev => {return {...prev, prevCoverArtUsed: getPlaylistData.data.coverArtFile}})

--- a/client/src/renderer/src/components/photoGallery/PhotoGallery.jsx
+++ b/client/src/renderer/src/components/photoGallery/PhotoGallery.jsx
@@ -21,7 +21,7 @@ function PhotoGallery(){
     const [pagnationPages, setPagnationPages] = useState(10)
     const [disablePrevUsedStatus, togglePrevUsed] = useState()
 
-    const hideText = <span>Hide previously used cover art in the cover art selection page when downloading</span>;
+    const hideText = <span>Hide previously used cover art in the cover art selection page when downloading playlists</span>;
     const moveText = <span>After download process finishes move the selected art into the subfolder in 'Documents/TuneRip/server/static/coverAlbums/used</span>;
     const deleteText = <span>After download finishes delete the selected cover art</span>;
 
@@ -90,7 +90,7 @@ function PhotoGallery(){
         },
         {
         title: 'Move cover art to the cover art subfolder',
-        description: 'After downloading the playlist move the cover art file to the subfolder located at "Documents/TuneRip/server/static/albumCovers/used',
+        description: 'After downloading the playlist move the cover art file to the subfolder located at "Documents/TuneRip/server/static/coverArt/used',
         target: () => moveCoverArtRef.current,
         },       
 
@@ -276,8 +276,12 @@ function PhotoGallery(){
 
 
 
-                    {/* <div className=" ">
+                    <div className=" ">
                         <div className="flex -ml-[10px]">
+
+                            <div className="text-red-500 mr-[5px] absolute -ml-[35px] mt-[0px] visible">
+                                NEW
+                            </div>
                             <div className="text-white absolute ">
                                 Delete art
                             </div>
@@ -289,14 +293,14 @@ function PhotoGallery(){
                             </Tooltip>           
                         </div>  
                         
-                    </div> */}
+                    </div>
 
 
-
-
-
-                    {/* <div className=" ">
+                    <div className=" ">
                         <div className="flex -ml-[5px]">
+                            <div className="text-red-500 mr-[5px] absolute -ml-[35px] mt-[0px] visible">
+                                NEW
+                            </div>
                             <div className="text-white absolute ">
                                Move art
                             </div>
@@ -307,7 +311,7 @@ function PhotoGallery(){
                                     <Switch  loading={postDownloadSetting.moveSwitchLoading} value={postDownloadSetting.moveSwitchChecked} onChange={(e) => handleMovetoSubfolder(e)} />  
                                 </Tooltip>         
                             </div>
-                    </div> */}
+                    </div>
                 </div>
             </>
           }

--- a/server/app/controllers/imageSettingsController.py
+++ b/server/app/controllers/imageSettingsController.py
@@ -126,7 +126,7 @@ class imageSettingsController():
 
         with open(self.file, 'w') as file:
             json.dump(currData, file, indent=4)  
-        return 'Selected cover art will now be moved to "Documents/TuneRip/server/static/albumCovers/used" after download' if req['data'] else 'Selected cover art will NOT be moved to the subfolder after download'
+        return 'Selected cover art will now be moved to "Documents/TuneRip/server/static/coverArt/used" after download' if req['data'] else 'Selected cover art will NOT be moved to the subfolder after download'
 
 
 

--- a/server/app/downloadFile.py
+++ b/server/app/downloadFile.py
@@ -165,8 +165,8 @@ def editTrackData(filePath='', album=None, artist=None, trackTitle=None, genre=N
         audio['TRCK'] = TRCK(encoding=3, text=str(trackNum)) # Track number
         updateData += 'track number, '
 
-    if coverArtFile and Path(Path.home() / 'Documents/server/static/albumCovers' / coverArtFile).exists:
-        with open( Path(Path.home() / 'Documents/TuneRip/server/static/albumCovers' / coverArtFile), 'rb') as coverArtFileBytes:
+    if coverArtFile and Path(Path.home() / 'Documents/server/static/coverArt' / coverArtFile).exists:
+        with open( Path(Path.home() / 'Documents/TuneRip/server/static/coverArt' / coverArtFile), 'rb') as coverArtFileBytes:
             cover_data = coverArtFileBytes.read()
             coverArtFileBytes.close()
         audio = MP3(filePath, ID3=ID3)

--- a/server/server.py
+++ b/server/server.py
@@ -17,7 +17,7 @@ from app.controllers.imageSettingsController import imageSettingsController
 basePath = Path.home() / 'Documents' / 'TuneRip'
 
 UPLOAD_FOLDER = basePath / 'server/static/channelImages'
-ALBUM_COVER_FOLDER = basePath / 'server/static/albumCovers'
+ALBUM_COVER_FOLDER = basePath / 'server/static/coverArt'
 DATABASE_FOLDER = basePath / 'server/database'
 
 
@@ -308,7 +308,7 @@ def getArtDownloadStatus():
 @app.get('/getChannelAndArtCoverData')
 def getChannelAndArtCoverData():
     data = controller_obj.returnAlbumCoverFileNames()
-    data['prevUsedCoverArtInfo'] = imageSettings_obj.getRecords()
+    data['coverArtSettings'] = imageSettings_obj.getRecords()
     return jsonify(data)
 
 @app.post('/toggleMoveImages')


### PR DESCRIPTION
- added switch and functionality to delete cover art file after downloading process finishes
- added switch and functionality to move cover art file to a subfolder after downloading process finishes
- added notifications if there are no cover art files
- added notifications if post delete settings are enabled
- added notifications if hide prev use is enabled and there are no cover art files available
- fixed pagination showing if there are no cover art files
- renamed albumCovers folder to coverArt and adjusted code